### PR TITLE
Resolve ambiguity between Lwt and Github.Monad

### DIFF
--- a/src/opam_publish.ml
+++ b/src/opam_publish.ml
@@ -239,14 +239,12 @@ module GH = struct
     try_again (c ?otp)
 
   let is_valid token = Lwt_main.run @@ Monad.(
-    catch (fun () -> run (
-      API.set_token token
-      >>= fun () ->
-      User.current_info ()
+    Lwt.catch (fun () -> run (
+      User.current_info ~token ()
       >>~ fun _ -> return true
     )) (function
       | Message (`Unauthorized, _) -> Lwt.return false
-      | exn -> fail exn
+      | exn -> Lwt.fail exn
     )
   )
 


### PR DESCRIPTION
Since github.2.2.0, `Lwt` and `Github.Monad` both contain values named `fail` and `catch`. This resolves that ambiguity by explicitly qualifying the `Lwt` names. This patch also simplifies the token
validity test slightly.