### PR TITLE
Restore pre-opam-2.5 compatibility

### DIFF
--- a/src/publishCompat.ml
+++ b/src/publishCompat.ml
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2012-2020 OCamlPro                                        *)
+(*    Copyright 2012 INRIA                                                *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* This module contains functions that was in `OpamStd` but where moved
+   to `OpamCompat`. We keep an compatibility module to be able to not depend
+   only on the last unreleased version of `OpamStd`. *)
+module String = struct
+  (** NOTE: OCaml >= 4.13 *)
+  let ends_with ~suffix s =
+    let x = String.length suffix in
+    let n = String.length s in
+    n >= x &&
+    let rec chk i = i >= x || suffix.[i] = s.[i+n-x] && chk (i+1) in
+    chk 0
+end

--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -441,7 +441,7 @@ module Args = struct
          let u = OpamUrl.of_string s in
          let src_opt =
            (if s <> "opam" && not (String.contains s '/') &&
-               not (OpamCompat.String.ends_with ~suffix:".opam" s)
+               not (PublishCompat.String.ends_with ~suffix:".opam" s)
             then
               try Some (`Name (OpamPackage.Name.of_string s))
               with Failure _ -> None


### PR DESCRIPTION
https://github.com/ocaml-opam/opam-publish/pull/173 broke compatibility with opam < 2.5 in opam-publish master.
opam-publish has 3 choices:
1. require opam >= 2.5 (current choice)
2. require OCaml >= 4.13
3. copy the missing function from `OpamCompat` over (this PR)

None of these choices are bad necessarily but option 1 makes it slightly more complicate to release new versions.
Option 2 would be fine but since opam-publish is a central ecosystem tool i think we should keep it for now until opam-repository moves over to a more recent version.

Option 3 allows us to know what is being used from 4.13 whenever we stop supporting older version and makes it relatively easy to track compatibility functions.