### PR TITLE
Advertise the need, and check, for the 'workflow' scope for github personal access tokens

### DIFF
--- a/opam-publish.opam
+++ b/opam-publish.opam
@@ -21,6 +21,8 @@ depends: [
   "opam-state" {>= "2.2.0"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
+  "cohttp" {>= "0.99"}
+  "cohttp-lwt-unix" {>= "0.99"}
 ]
 flags: plugin
 synopsis: "A tool to ease contributions to opam repositories"


### PR DESCRIPTION
Fixes #180 
Description in the individual commits.
The "new" cohttp dependencies are here just to make the use explicit, but these are already a dependency of `github-unix`.